### PR TITLE
Protect nodes

### DIFF
--- a/permissions/protect_nodes/config/install/protect_nodes.settings.yml
+++ b/permissions/protect_nodes/config/install/protect_nodes.settings.yml
@@ -1,1 +1,1 @@
-protected_urls: "/homepage\r\n/family-food\r\n/community-development\r\n/4h\r\n/agriculture-environment\r\n/about-us\r\n/events\r\n/extension-council"
+protected_urls: '/homepage2,/family-food,/community-development,/4h,/agriculture-environment,/about-us,/events,/extension-council'

--- a/permissions/protect_nodes/config/install/protect_nodes.settings.yml
+++ b/permissions/protect_nodes/config/install/protect_nodes.settings.yml
@@ -1,0 +1,1 @@
+protected_urls: "/homepage\r\n/family-food\r\n/community-development\r\n/4h\r\n/agriculture-environment\r\n/about-us\r\n/events\r\n/extension-council"

--- a/permissions/protect_nodes/config/install/protect_nodes.settings.yml
+++ b/permissions/protect_nodes/config/install/protect_nodes.settings.yml
@@ -1,1 +1,2 @@
 protect_nodes: '/homepage,/family-food,/community-development,/4h,/agriculture-environment,/about-us,/events,/extension-council'
+protect_titles: ''

--- a/permissions/protect_nodes/config/install/protect_nodes.settings.yml
+++ b/permissions/protect_nodes/config/install/protect_nodes.settings.yml
@@ -1,1 +1,1 @@
-protected_urls: '/homepage2,/family-food,/community-development,/4h,/agriculture-environment,/about-us,/events,/extension-council'
+protect_nodes: '/homepage,/family-food,/community-development,/4h,/agriculture-environment,/about-us,/events,/extension-council'

--- a/permissions/protect_nodes/config/install/protect_nodes.settings.yml
+++ b/permissions/protect_nodes/config/install/protect_nodes.settings.yml
@@ -1,2 +1,2 @@
 protect_nodes: '/homepage,/family-food,/community-development,/4h,/agriculture-environment,/about-us,/events,/extension-council'
-protect_titles: ''
+protect_titles: '/camps-outreach,/clover-kids,/club-resources,/join-4-h,/newsletter,/school-enrichment,/record-keeping,/club-directory,/recognitionawards,/summer-programs,/youth-programs,/youth-outreach-resources,/county-fair,/volunteer-resources,/volunteerresources,/newsletters,/4-h-newsletters'

--- a/permissions/protect_nodes/protect_nodes.info.yml
+++ b/permissions/protect_nodes/protect_nodes.info.yml
@@ -1,0 +1,6 @@
+name: Protect Nodes
+description: Don't allow certain nodes to be deleted
+package: Custom
+type: module
+version: 1.0
+core_version_requirement: ^8 || ^9

--- a/permissions/protect_nodes/protect_nodes.links.menu.yml
+++ b/permissions/protect_nodes/protect_nodes.links.menu.yml
@@ -1,0 +1,6 @@
+protect_nodes.settings_form:
+  title: 'Protect Nodes Settings'
+  route_name: protect_nodes.settings_form
+  description: 'Settings for the protect_nodes Module'
+  parent: system.admin_config_content
+  weight: 100

--- a/permissions/protect_nodes/protect_nodes.module
+++ b/permissions/protect_nodes/protect_nodes.module
@@ -58,7 +58,8 @@ function protect_nodes_form_alter(&$form, \Drupal\Core\Form\FormStateInterface $
     if (in_array($url, $protected_nodes) || in_array($url, $protected_titles)) {
       // Don't allow changing title or url path
       $form['title']['widget']['#disabled'] = TRUE;
-      unset($form['path']);
+      unset($form['path']); // Remove URL ALIAS (path) options
+      unset($form['status']); // Remove status/published checkbox
     }
   }
 

--- a/permissions/protect_nodes/protect_nodes.module
+++ b/permissions/protect_nodes/protect_nodes.module
@@ -1,5 +1,6 @@
 <?php
 
+use Drupal\Core\Entity\EntityForm;
 use Drupal\node\Entity\Node;
 
 /**
@@ -8,28 +9,49 @@ use Drupal\node\Entity\Node;
 
 function protect_nodes_form_alter(&$form, \Drupal\Core\Form\FormStateInterface $form_state, $form_id)
 {
+  // Get protected urls
   $config = Drupal::configFactory()->get('protect_nodes.settings');
-  $protected_urls = explode(PHP_EOL, $config->get('protected_urls'));
+  $protected_urls = explode(',', $config->get('protected_urls'));
 
-  if (strpos($form_id, 'node') !== false && strpos($form_id, 'delete_form') !== false && $form_id != "node_type_delete_form") {
-
+  // Check if its a Node form, and if so, get the URL
+  $url = '';
+  if ($form_state->getFormObject() instanceof EntityForm) {
     $node = Node::load($form_state->getFormObject()->getEntity()->id());
-    $url = Drupal::service('path_alias.manager')->getAliasByPath('/node/' . $node->id());
-    if (in_array($url, $protected_urls)) {
+    if (!empty($node)) {
+      $url = Drupal::service('path_alias.manager')->getAliasByPath('/node/' . $node->id());
+    }
+  }
 
+  // Check if it's a node delete form
+  if (strpos($form_id, 'node') !== false && strpos($form_id, 'delete_form') !== false && $form_id != "node_type_delete_form") {
+    // Check if this node is protected
+    if (in_array($url, $protected_urls)) {
+      // Construct message
       $results = '<p class="protect_nodes">';
       $results .= '<strong>' . $node->getTitle() . '</strong>';
       $results .= ' is a required page on this site, and can not be deleted';
       $results .= '</p>' . PHP_EOL;
 
+      // Display message
       $form['protect_nodes'] = array(
         '#markup' => $results,
         '#weight' => -10,
       );
 
+      // Don't allow deleting this node
       $form['actions']['cancel']['#title'] = t('Go back');
       unset($form['description']);
       unset($form['actions']['submit']);
+    }
+  }
+
+  // Check if it's a node edit form
+  if (strpos($form_id, 'node') !== false && strpos($form_id, 'edit_form') !== false && $form_id != "node_type_edit_form") {
+    //Check if the title and url path are protected
+    if (in_array($url, $protected_urls)) {
+      // Don't allow changing title or url path
+      $form['title']['widget']['#disabled'] = TRUE;
+      unset($form['path']);
     }
   }
 }

--- a/permissions/protect_nodes/protect_nodes.module
+++ b/permissions/protect_nodes/protect_nodes.module
@@ -48,6 +48,7 @@ function protect_nodes_form_alter(&$form, \Drupal\Core\Form\FormStateInterface $
       $form['actions']['cancel']['#title'] = t('Go back');
       unset($form['description']);
       unset($form['actions']['submit']);
+      unset($form['actions']['cancel']);
     }
   }
 
@@ -58,6 +59,37 @@ function protect_nodes_form_alter(&$form, \Drupal\Core\Form\FormStateInterface $
       // Don't allow changing title or url path
       $form['title']['widget']['#disabled'] = TRUE;
       unset($form['path']);
+    }
+  }
+
+  // Handle multiple deleting from the content menu
+  if ($form_id == 'node_delete_multiple_confirm_form') {
+    $list_items = '';
+
+    // Step through each node in the list
+    foreach ($form['entities']['#items'] as $key => $value) {
+      $node_info = explode(':', $key);
+      $url = Drupal::service('path_alias.manager')->getAliasByPath('/node/' . $node_info[0]);
+
+      // Check if it's protected
+      if (in_array($url, $protected_nodes)) {
+        $list_items .= '<li>' . $value . '</li>' . PHP_EOL;
+      }
+    }
+
+    // Do we have any protected nodes in the list
+    if (!empty($list_items)) {
+      // Give our error message
+      $form['protect_nodes'] = array(
+        '#markup' => '<p>These nodes can\'t be deleted because the following node(s) are protected:</p>' . PHP_EOL . '<ol>' . $list_items . '</ol>' . PHP_EOL,
+        '#weight' => 10,
+      );
+
+      // Modify the form
+      $form['actions']['cancel']['#title'] = t('Go back');
+      unset($form['description']);
+      unset($form['actions']['submit']);
+      unset($form['actions']['cancel']);
     }
   }
 }

--- a/permissions/protect_nodes/protect_nodes.module
+++ b/permissions/protect_nodes/protect_nodes.module
@@ -16,7 +16,7 @@ function protect_nodes_form_alter(&$form, \Drupal\Core\Form\FormStateInterface $
 
   // Get protected urls
   $config = Drupal::configFactory()->get('protect_nodes.settings');
-  $protected_urls = explode(',', $config->get('protected_urls'));
+  $protected_nodes = explode(',', $config->get('protect_nodes'));
 
   // Check if its a Node form, and if so, get the URL
   $url = '';
@@ -30,7 +30,7 @@ function protect_nodes_form_alter(&$form, \Drupal\Core\Form\FormStateInterface $
   // Check if it's a node delete form
   if (strpos($form_id, 'node') !== false && strpos($form_id, 'delete_form') !== false && $form_id != "node_type_delete_form") {
     // Check if this node is protected
-    if (in_array($url, $protected_urls)) {
+    if (in_array($url, $protected_nodes)) {
       // Construct message
       $results = '<p class="protect_nodes">';
       $results .= '<strong>' . $node->getTitle() . '</strong>';
@@ -53,7 +53,7 @@ function protect_nodes_form_alter(&$form, \Drupal\Core\Form\FormStateInterface $
   // Check if it's a node edit form
   if (strpos($form_id, 'node') !== false && strpos($form_id, 'edit_form') !== false && $form_id != "node_type_edit_form") {
     //Check if the title and url path are protected
-    if (in_array($url, $protected_urls)) {
+    if (in_array($url, $protected_nodes)) {
       // Don't allow changing title or url path
       $form['title']['widget']['#disabled'] = TRUE;
       unset($form['path']);

--- a/permissions/protect_nodes/protect_nodes.module
+++ b/permissions/protect_nodes/protect_nodes.module
@@ -9,6 +9,11 @@ use Drupal\node\Entity\Node;
 
 function protect_nodes_form_alter(&$form, \Drupal\Core\Form\FormStateInterface $form_state, $form_id)
 {
+  // Don't restrict adminn, it's their foot :-)
+  if (Drupal::currentUser()->id() == 1) {
+    //return;
+  }
+
   // Get protected urls
   $config = Drupal::configFactory()->get('protect_nodes.settings');
   $protected_urls = explode(',', $config->get('protected_urls'));

--- a/permissions/protect_nodes/protect_nodes.module
+++ b/permissions/protect_nodes/protect_nodes.module
@@ -3,37 +3,33 @@
 use Drupal\node\Entity\Node;
 
 /**
-* Implements hook_form_alter().
-*/
+ * Implements hook_form_alter().
+ */
 
-function protect_nodes_form_alter(&$form, \Drupal\Core\Form\FormStateInterface $form_state, $form_id) {
-  //Drupal::logger('protect_nodes')->info('In hook_form_alter: ' . $form_id);
+function protect_nodes_form_alter(&$form, \Drupal\Core\Form\FormStateInterface $form_state, $form_id)
+{
+  $config = Drupal::configFactory()->get('protect_nodes.settings');
+  $protected_urls = explode(PHP_EOL, $config->get('protected_urls'));
 
-  //if ($form_id == 'node_staff_profile_delete_form') {
   if (strpos($form_id, 'node') !== false && strpos($form_id, 'delete_form') !== false && $form_id != "node_type_delete_form") {
 
-  $node = Node::load($form_state->getFormObject()->getEntity()->id());
-  //Drupal::logger('protect_nodes')->info(json_encode($form['actions']));
+    $node = Node::load($form_state->getFormObject()->getEntity()->id());
+    $url = Drupal::service('path_alias.manager')->getAliasByPath('/node/' . $node->id());
+    if (in_array($url, $protected_urls)) {
 
-  $results = '<ul>';
-  $results .= '<li>' . $form_id . '</li>';
-  $results .= '<li>' . $node->id() . '</li>';
-  $results .= '<li>' . $node->getTitle() . '</li>';
-  $results .= '<li>' . Drupal::service('path_alias.manager')->getAliasByPath('/node/' . $node->id()) . '</li>';
-  $results .= '<li>' . $node->getType() . '</li>';
-  $results .= '</ul>';
+      $results = '<p class="protect_nodes">';
+      $results .= '<strong>' . $node->getTitle() . '</strong>';
+      $results .= ' is a required page on this site, and can not be deleted';
+      $results .= '</p>' . PHP_EOL;
 
-    $form['protect_nodes'] = array(
-      '#markup' => $results,
-      '#weight' => -10,
-    );
+      $form['protect_nodes'] = array(
+        '#markup' => $results,
+        '#weight' => -10,
+      );
 
-    $form['actions']['cancel']['#title'] = t('Go back');
-    //$form['actions']['Cancel']['#value'] = t('Go back');
-    //$form['cancel']['#value'] = t('Go back');
-    unset($form['description']);
-    unset($form['actions']['submit']);
+      $form['actions']['cancel']['#title'] = t('Go back');
+      unset($form['description']);
+      unset($form['actions']['submit']);
+    }
   }
 }
-
-

--- a/permissions/protect_nodes/protect_nodes.module
+++ b/permissions/protect_nodes/protect_nodes.module
@@ -11,12 +11,13 @@ function protect_nodes_form_alter(&$form, \Drupal\Core\Form\FormStateInterface $
 {
   // Don't restrict adminn, it's their foot :-)
   if (Drupal::currentUser()->id() == 1) {
-    //return;
+    return;
   }
 
   // Get protected urls
   $config = Drupal::configFactory()->get('protect_nodes.settings');
   $protected_nodes = explode(',', $config->get('protect_nodes'));
+  $protected_titles = explode(',', $config->get('protect_titles'));
 
   // Check if its a Node form, and if so, get the URL
   $url = '';
@@ -53,7 +54,7 @@ function protect_nodes_form_alter(&$form, \Drupal\Core\Form\FormStateInterface $
   // Check if it's a node edit form
   if (strpos($form_id, 'node') !== false && strpos($form_id, 'edit_form') !== false && $form_id != "node_type_edit_form") {
     //Check if the title and url path are protected
-    if (in_array($url, $protected_nodes)) {
+    if (in_array($url, $protected_nodes) || in_array($url, $protected_titles)) {
       // Don't allow changing title or url path
       $form['title']['widget']['#disabled'] = TRUE;
       unset($form['path']);

--- a/permissions/protect_nodes/protect_nodes.module
+++ b/permissions/protect_nodes/protect_nodes.module
@@ -1,0 +1,39 @@
+<?php
+
+use Drupal\node\Entity\Node;
+
+/**
+* Implements hook_form_alter().
+*/
+
+function protect_nodes_form_alter(&$form, \Drupal\Core\Form\FormStateInterface $form_state, $form_id) {
+  //Drupal::logger('protect_nodes')->info('In hook_form_alter: ' . $form_id);
+
+  //if ($form_id == 'node_staff_profile_delete_form') {
+  if (strpos($form_id, 'node') !== false && strpos($form_id, 'delete_form') !== false && $form_id != "node_type_delete_form") {
+
+  $node = Node::load($form_state->getFormObject()->getEntity()->id());
+  //Drupal::logger('protect_nodes')->info(json_encode($form['actions']));
+
+  $results = '<ul>';
+  $results .= '<li>' . $form_id . '</li>';
+  $results .= '<li>' . $node->id() . '</li>';
+  $results .= '<li>' . $node->getTitle() . '</li>';
+  $results .= '<li>' . Drupal::service('path_alias.manager')->getAliasByPath('/node/' . $node->id()) . '</li>';
+  $results .= '<li>' . $node->getType() . '</li>';
+  $results .= '</ul>';
+
+    $form['protect_nodes'] = array(
+      '#markup' => $results,
+      '#weight' => -10,
+    );
+
+    $form['actions']['cancel']['#title'] = t('Go back');
+    //$form['actions']['Cancel']['#value'] = t('Go back');
+    //$form['cancel']['#value'] = t('Go back');
+    unset($form['description']);
+    unset($form['actions']['submit']);
+  }
+}
+
+

--- a/permissions/protect_nodes/protect_nodes.routing.yml
+++ b/permissions/protect_nodes/protect_nodes.routing.yml
@@ -4,6 +4,6 @@ protect_nodes.settings_form:
     _form: '\Drupal\protect_nodes\Form\SettingsForm'
     _title: 'Protect Nodes Settings'
   requirements:
-    _permission: 'access content'
+    _permission: 'administer content'
   options:
     _admin-route: TRUE

--- a/permissions/protect_nodes/protect_nodes.routing.yml
+++ b/permissions/protect_nodes/protect_nodes.routing.yml
@@ -1,0 +1,9 @@
+protect_nodes.settings_form:
+  path: 'admin/config/content/protect_nodes_settings'
+  defaults:
+    _form: '\Drupal\protect_nodes\Form\SettingsForm'
+    _title: 'Protect Nodes Settings'
+  requirements:
+    _permission: 'access content'
+  options:
+    _admin-route: TRUE

--- a/permissions/protect_nodes/src/Form/SettingsForm.php
+++ b/permissions/protect_nodes/src/Form/SettingsForm.php
@@ -36,6 +36,7 @@ class SettingsForm extends ConfigFormBase {
         '#description' => $this->t('Example: <br/>&nbsp;&nbsp;/homepage<br/>&nbsp;&nbsp;/events<br/>Separate each url with a new line'),
         '#size' => 64,
         '#default_value' => !empty($config->get('protected_urls')) ? preg_replace('/,/',"\r\n",$config->get('protected_urls')) : '',
+        //'#default_value' => $config->get('protected_urls'),
         '#required' => TRUE,
       );
 
@@ -47,8 +48,15 @@ class SettingsForm extends ConfigFormBase {
      */
     public function submitForm(array &$form, FormStateInterface $form_state) {
       parent::submitForm($form, $form_state);
+
+      $urls = explode(PHP_EOL, trim($form_state->getValue('protected_urls')));
+      $trimmed_urls = [];
+      foreach($urls as $url) {
+        $trimmed_urls[] = trim($url);
+      }
       //If checked, run sync
       $this->config('protect_nodes.settings')
+        //->set('protected_urls', implode(',', $trimmed_urls))
         //->set('protected_urls', trim($form_state->getValue('protected_urls')))
         ->set('protected_urls', preg_replace('/\s+(?=[hw])/',',',trim($form_state->getValue('protected_urls'))))
         ->save();

--- a/permissions/protect_nodes/src/Form/SettingsForm.php
+++ b/permissions/protect_nodes/src/Form/SettingsForm.php
@@ -36,7 +36,14 @@ class SettingsForm extends ConfigFormBase {
         '#description' => $this->t('Example (Separate each url with a new line): <br/>&nbsp;&nbsp;/homepage<br/>&nbsp;&nbsp;/events'),
         '#size' => 64,
         '#default_value' => !empty($config->get('protect_nodes')) ? preg_replace('/,/',"\r\n",$config->get('protect_nodes')) : '',
-        '#required' => TRUE,
+      );
+
+      $form['protect_titles'] = array(
+        '#type' => 'textarea',
+        '#title' => $this->t('Prevents users from changing the title and/or URL'),
+        '#description' => $this->t('Example (Separate each url with a new line): <br/>&nbsp;&nbsp;/homepage<br/>&nbsp;&nbsp;/events'),
+        '#size' => 64,
+        '#default_value' => !empty($config->get('protect_titles')) ? preg_replace('/,/',"\r\n",$config->get('protect_titles')) : '',
       );
 
       return parent::buildForm($form, $form_state);
@@ -48,14 +55,21 @@ class SettingsForm extends ConfigFormBase {
     public function submitForm(array &$form, FormStateInterface $form_state) {
       parent::submitForm($form, $form_state);
 
-      $urls = explode(PHP_EOL, trim($form_state->getValue('protect_nodes')));
-      $trimmed_urls = [];
-      foreach($urls as $url) {
-        $trimmed_urls[] = trim($url);
+      $nodes = explode(PHP_EOL, trim($form_state->getValue('protect_nodes')));
+      $trimmed_nodes = [];
+      foreach($nodes as $nodes) {
+        $trimmed_nodes[] = trim($nodes);
+      }
+
+      $titles = explode(PHP_EOL, trim($form_state->getValue('protect_titles')));
+      $trimmed_titles = [];
+      foreach($titles as $titles) {
+        $trimmed_titles[] = trim($titles);
       }
       //If checked, run sync
       $this->config('protect_nodes.settings')
-        ->set('protect_nodes', implode(',', $trimmed_urls))
+        ->set('protect_nodes', implode(',', $trimmed_nodes))
+        ->set('protect_titles', implode(',', $trimmed_titles))
         ->save();
   }
 }

--- a/permissions/protect_nodes/src/Form/SettingsForm.php
+++ b/permissions/protect_nodes/src/Form/SettingsForm.php
@@ -30,13 +30,12 @@ class SettingsForm extends ConfigFormBase {
     */
     public function buildForm(array $form, FormStateInterface $form_state) {
       $config = $this->config('protect_nodes.settings');
-      $form['protected_urls'] = array(
+      $form['protect_nodes'] = array(
         '#type' => 'textarea',
-        '#title' => $this->t('URLs of protected pages'),
-        '#description' => $this->t('Example: <br/>&nbsp;&nbsp;/homepage<br/>&nbsp;&nbsp;/events<br/>Separate each url with a new line'),
+        '#title' => $this->t('Prevents users from deleting these nodes, or changing the title and/or URL'),
+        '#description' => $this->t('Example (Separate each url with a new line): <br/>&nbsp;&nbsp;/homepage<br/>&nbsp;&nbsp;/events'),
         '#size' => 64,
-        '#default_value' => !empty($config->get('protected_urls')) ? preg_replace('/,/',"\r\n",$config->get('protected_urls')) : '',
-        //'#default_value' => $config->get('protected_urls'),
+        '#default_value' => !empty($config->get('protect_nodes')) ? preg_replace('/,/',"\r\n",$config->get('protect_nodes')) : '',
         '#required' => TRUE,
       );
 
@@ -49,14 +48,14 @@ class SettingsForm extends ConfigFormBase {
     public function submitForm(array &$form, FormStateInterface $form_state) {
       parent::submitForm($form, $form_state);
 
-      $urls = explode(PHP_EOL, trim($form_state->getValue('protected_urls')));
+      $urls = explode(PHP_EOL, trim($form_state->getValue('protect_nodes')));
       $trimmed_urls = [];
       foreach($urls as $url) {
         $trimmed_urls[] = trim($url);
       }
       //If checked, run sync
       $this->config('protect_nodes.settings')
-        ->set('protected_urls', implode(',', $trimmed_urls))
+        ->set('protect_nodes', implode(',', $trimmed_urls))
         ->save();
   }
 }

--- a/permissions/protect_nodes/src/Form/SettingsForm.php
+++ b/permissions/protect_nodes/src/Form/SettingsForm.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Drupal\protect_nodes\Form;
+
+use Drupal\Core\Form\ConfigFormBase;
+use Drupal\Core\Form\FormStateInterface;
+
+/*
+ * Class SettingsForm
+ */
+class SettingsForm extends ConfigFormBase {
+  /**
+   * {@inheritdoc}
+   */
+  protected function getEditableConfigNames() {
+    return [
+      'protect_nodes.settings',
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+   public function getFormID() {
+     return 'settings_form';
+   }
+
+   /**
+    * {@inheritdoc}
+    */
+    public function buildForm(array $form, FormStateInterface $form_state) {
+      $config = $this->config('protect_nodes.settings');
+      $form['protected_urls'] = array(
+        '#type' => 'textarea',
+        '#title' => $this->t('URLs of protected pages'),
+        '#description' => $this->t('Example: <br/>&nbsp;&nbsp;/homepage<br/>&nbsp;&nbsp;/events<br/>Separate each url with a new line'),
+        '#size' => 64,
+        '#default_value' => !empty($config->get('protected_urls')) ? preg_replace('/,/',"\r\n",$config->get('protected_urls')) : '',
+        '#required' => TRUE,
+      );
+
+      return parent::buildForm($form, $form_state);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function submitForm(array &$form, FormStateInterface $form_state) {
+      parent::submitForm($form, $form_state);
+      //If checked, run sync
+      $this->config('protect_nodes.settings')
+        //->set('protected_urls', trim($form_state->getValue('protected_urls')))
+        ->set('protected_urls', preg_replace('/\s+(?=[hw])/',',',trim($form_state->getValue('protected_urls'))))
+        ->save();
+  }
+}

--- a/permissions/protect_nodes/src/Form/SettingsForm.php
+++ b/permissions/protect_nodes/src/Form/SettingsForm.php
@@ -56,9 +56,7 @@ class SettingsForm extends ConfigFormBase {
       }
       //If checked, run sync
       $this->config('protect_nodes.settings')
-        //->set('protected_urls', implode(',', $trimmed_urls))
-        //->set('protected_urls', trim($form_state->getValue('protected_urls')))
-        ->set('protected_urls', preg_replace('/\s+(?=[hw])/',',',trim($form_state->getValue('protected_urls'))))
+        ->set('protected_urls', implode(',', $trimmed_urls))
         ->save();
   }
 }


### PR DESCRIPTION
This will protect nodes from being deleted and/or the titles/urls from being changed

- Adds a menu item Configuration->Content Authoring->Protect Nodes Settings
- Alters the node delete confirmation pages to take away the submit button on protected pages
- Alters the node edit pages to protect the title and url/path
- Alters the multiple node deletion confirmation page, to take away the submit button if any of the nodes are protected
- Only does deletes alters the pages for editors, adminn is still free to do what we want to do
