### PR TITLE
Cache files

### DIFF
--- a/isueo_helpers/src/ISUEOHelpers/Files.php
+++ b/isueo_helpers/src/ISUEOHelpers/Files.php
@@ -8,6 +8,9 @@ use Drupal\Core\Site\Settings;
 class Files
 {
 
+  // 900 seconds = 15 minutes
+  public static const CACHE_SECONDS = 900;
+
   // Get a file from a URL
   // TODO: Add some sort of caching mechanism
   public static function fetch_url(string $url, bool $ok_to_cache = false)
@@ -26,10 +29,11 @@ class Files
         $creds .= '@';
       }
 
-      // Insert the credentials and get file
+      // Insert the credentials into the URL
       $url = str_replace('https://', 'https://' . $creds, $url);
     }
 
+    // Get the page and return the results
     return file_get_contents($url);
   }
 }

--- a/isueo_helpers/src/ISUEOHelpers/Files.php
+++ b/isueo_helpers/src/ISUEOHelpers/Files.php
@@ -9,15 +9,38 @@ class Files
 {
 
   // 900 seconds = 15 minutes
-  public static const CACHE_SECONDS = 900;
+  public const CACHE_SECONDS = 900;
 
   // Get a file from a URL
   // TODO: Add some sort of caching mechanism
-  public static function fetch_url(string $url, bool $ok_to_cache = false)
+  public static function fetch_url(string $url, bool $use_cache = false)
   {
+    // Initialize some variables
+    $update_cache = false;
+    $cache_file_path = '';
     $creds = '';
     $url = str_replace('http://', 'https://', $url);
 
+    // Check whether it's OK to use a cached file
+    if ($use_cache) {
+      // Get the path to the cached file, the Upcoming Program Offerings file may include a
+      // timestamp as a query parameter, but we don't have to worry about that
+      $cache_url = $url;
+      if (str_starts_with(strtolower($cache_url), 'https://datastore.exnet.iastate.edu/mydata/upcomingprogramofferings.json')) {
+        $cache_url = 'https://datastore.exnet.iastate.edu/mydata/UpcomingProgramOfferings.json';
+      }
+      $cache_file_path = '/tmp/isueo_helpers/' . md5($cache_url);
+
+
+      // If the file exists and is new enough, use it
+      if (file_exists($cache_file_path) && ((time() - filemtime($cache_file_path)) < Files::CACHE_SECONDS)) {
+        return file_get_contents($cache_file_path);
+      } else {
+        $update_cache = true;
+      }
+    }
+
+    // The datastore needs special credentials to access via https
     if (str_starts_with(strtolower($url), 'https://datastore')) {
       // Get credentials for the datastore
       $creds = Settings::get('datastore_creds');
@@ -33,7 +56,26 @@ class Files
       $url = str_replace('https://', 'https://' . $creds, $url);
     }
 
-    // Get the page and return the results
-    return file_get_contents($url);
+    // Get the page
+    $results = file_get_contents($url);
+
+    // Check if we should write the results to cache
+    if ($use_cache && $update_cache) {
+      // Make sure the folder exists
+      if (file_exists('/tmp')) {
+        if (!file_exists('/tmp/isueo_helpers') && is_writable('/tmp')) {
+          mkdir('/tmp/isueo_helpers');
+        }
+      }
+
+      // If the folder is writable, and we have valid results, then write the file to the cache folder
+      if (is_writable('/tmp/isueo_helpers') && count(json_decode($results, true)) > 0 ) {
+        file_put_contents($cache_file_path, $results);
+      }
+
+    }
+
+    // Finally, return the results
+    return $results;
   }
 }

--- a/program_offerings/program_offering_blocks/src/Controller/EventDetailsController.php
+++ b/program_offerings/program_offering_blocks/src/Controller/EventDetailsController.php
@@ -27,7 +27,7 @@ class EventDetailsController extends ControllerBase
 
     //    $eventID = intval($eventID);
     $module_config = \Drupal::config('program_offering_blocks.settings');
-    $buffer = ISUEOHelpers\Files::fetch_url($module_config->get('url'));
+    $buffer = ISUEOHelpers\Files::fetch_url($module_config->get('url'), true);
     $program_offerings = json_decode($buffer, TRUE);
 
     foreach ($program_offerings as $event) {

--- a/program_offerings/program_offering_blocks/src/Plugin/Block/ProgramOfferingBlocks.php
+++ b/program_offerings/program_offering_blocks/src/Plugin/Block/ProgramOfferingBlocks.php
@@ -100,7 +100,7 @@ class ProgramOfferingBlocks extends BlockBase
     // Set the timeout to 2 seconds, Get the events from the JSON feed, then reset timeout to previous value
     $default_socket_timeout = ini_get('default_socket_timeout');
     ini_set('default_socket_timeout', 2);
-    $buffer = ISUEOHelpers\Files::fetch_url($module_config->get('url') . '?time=' . time());
+    $buffer = ISUEOHelpers\Files::fetch_url($module_config->get('url') . '?time=' . time(), true);
     ini_set('default_socket_timeout', $default_socket_timeout);
     $json_events = json_decode($buffer, TRUE);
 


### PR DESCRIPTION
One of the things that make our web pages slow, is that we do a web call to get a JSON file of events every time we need to display a list of events, or event details. This includes every call to a county home page. 

This pull request tries to write that JSON file to the /tmp folder on the server. If this work, then it will read try to read the file from here, rather than the web, for the next 15 minutes. This should speed up the county sites quite a bit...