### PR TITLE
Add text to Featured Resource Arrows

### DIFF
--- a/pubs_entity/pubs_entity_type/css/pubs_entity_type.css
+++ b/pubs_entity/pubs_entity_type/css/pubs_entity_type.css
@@ -98,3 +98,8 @@ button.slick-next, button.slick-prev {
 	font-size: 22px;
 	color: #fff;
 }
+
+.slick-prev, .slick-next {
+	font-size: 0;
+}
+


### PR DESCRIPTION
Add text to "Previous Arrow" and "Next Arrow" in Publication Carousel Configuration settings, adds text to aria-label in HTML and this CSS change hides the visible text

![Screen Shot 2023-10-20 at 1 19 00 PM (3)](https://github.com/isueit/d8modules/assets/116776020/97e319d6-4084-439d-a4e3-00af02daecbc)

