### PR TITLE
Stop flip animation when opening links

### DIFF
--- a/flip_cards/css/flip_cards.css
+++ b/flip_cards/css/flip_cards.css
@@ -275,3 +275,8 @@ p.flip-card_button {
 	background-color: #003D4C;
 	border: 2px solid #003d4c;
 }
+
+.flip-card:focus-within {
+  	transition: none;
+}
+


### PR DESCRIPTION
still trying to find a way to make it stay on the back of the card instead of going back to front, but this stops the animation from happening